### PR TITLE
add script for fetching toolchain

### DIFF
--- a/wget_toolchain
+++ b/wget_toolchain
@@ -1,0 +1,18 @@
+#!/bin/sh
+#*******************************************************************************
+#     DOWNLOAD TOOLCHAIN
+#*******************************************************************************
+# as normal user on linux pc terminal:
+
+echo
+echo ---------------------------------------------------------------------------
+echo DOWNLOADING TOOLCHAIN
+echo ---------------------------------------------------------------------------
+echo
+
+project=`pwd`
+download_file=`tempfile`
+wget -O ${download_file} https://sourcery.mentor.com/GNUToolchain/package8734/public/arm-none-eabi/arm-2011.03-42-arm-none-eabi-i686-pc-linux-gnu.tar.bz2
+mkdir -p ${project}/../bin
+tar -C ${project}/../bin -xjf ${download_file}
+rm ${download_file}


### PR DESCRIPTION
this downloads and installs the toolchain in the correct place so that ./build_kernel can actually compile the kernel
