### PR TITLE
Add the "Projects That Use ev3dev" page to the static site

### DIFF
--- a/Projects.html
+++ b/Projects.html
@@ -1,0 +1,72 @@
+﻿<!doctype html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="chrome=1">
+    <title>Projects That Use ev3dev</title>
+    <link rel="stylesheet" href="stylesheets/styles.css">
+    <link rel="stylesheet" href="stylesheets/pygment_trac.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+    <script src="javascripts/respond.js"></script>
+    <!--[if lt IE 9]>
+      <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <![endif]-->
+    <!--[if lt IE 8]>
+    <link rel="stylesheet" href="stylesheets/ie.css">
+    <![endif]-->
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+</head>
+<body>
+    <div id="header">
+        <nav>
+            <li class="home"><a href="index.html">Home</a></li>
+            <li class="projects"><a href="Projects.html">Projects That Use ev3dev</a></li>
+            
+            <li class="wiki"><a href="https://github.com/mindboards/ev3dev/wiki">Wiki</a></li>
+            <li class="issues"><a href="https://github.com/mindboards/ev3dev/issues">Issues</a></li>
+            <li class="fork"><a href="https://github.com/mindboards/ev3dev">View On GitHub</a></li>
+
+            <!--<li class="otherPlaces"><a href="https://github.com/mindboards/ev3dev-kernel">KERNEL</a></li>
+            <li class="otherPlaces"><a href="https://github.com/mindboards/ev3dev-rootfs">BUILD SCRIPTS</a></li>
+            <li class="otherPlaces"><a href="https://github.com/ev3dev">PACKAGES</a></li>
+            <li class="title">OTHER PLACES</li>-->
+        </nav>
+    </div><!-- end header -->
+
+    <div class="wrapper">
+
+        <section>
+            <div id="title">
+                <div id="logoContainer">
+                    <a href="index.html">
+                        <img id="logo" src="https://avatars3.githubusercontent.com/u/6878323?s=140" />
+                    </a>
+                    <div id="titleHeader" class="clear">
+                        <h1>Projects</h1>
+                        <p>Projects that use ev3dev</p>
+                    </div>
+                </div>
+                <hr class="clear">
+                <span class="credits left">Project maintained by <a href="https://github.com/rhempel">Ralph Hempel</a> and <a href="https://github.com/dlech">David Lechner</a>, with help from the community</span>
+                <span class="credits right">Hosted on GitHub Pages <!--&mdash; Theme by <a href="https://twitter.com/michigangraham">mattgraham</a>--></span>
+            </div>
+
+            <p>
+                This is where we keep a collection of all the projects that people are working on using ev3dev. We invite you to click through the links below to see what cool stuff ev3dev can do!
+            </p>
+            <ul>
+                <li><a href="https://github.com/mindboards/ev3dev/issues/63#issuecomment-42717732">Rubik's cube solver by @cavenel</a></li>
+                <li><a href="https://gist.github.com/dlech/11098915">Balancing robot by @dlech and @G33kDude</a></li>
+                <li><a href="http://youtu.be/9pjpQoZoW6E">Drawing robot by @cavenel</a></li>
+            </ul>
+
+        </section>
+        <hr />
+
+
+    </div>
+    <!--[if !IE]><script>fixScale(document);</script><![endif]-->
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -20,14 +20,17 @@
 <body>
     <div id="header">
         <nav>
-            <li class="fork"><a href="https://github.com/mindboards/ev3dev">View On GitHub</a></li>
+            <li class="home"><a href="index.html">Home</a></li>
+            <li class="projects"><a href="Projects.html">Projects That Use ev3dev</a></li>
+
             <li class="wiki"><a href="https://github.com/mindboards/ev3dev/wiki">Wiki</a></li>
             <li class="issues"><a href="https://github.com/mindboards/ev3dev/issues">Issues</a></li>
+            <li class="fork"><a href="https://github.com/mindboards/ev3dev">View On GitHub</a></li>
 
-            <li class="otherPlaces"><a href="https://github.com/mindboards/ev3dev-kernel">KERNEL</a></li>
+            <!--<li class="otherPlaces"><a href="https://github.com/mindboards/ev3dev-kernel">KERNEL</a></li>
             <li class="otherPlaces"><a href="https://github.com/mindboards/ev3dev-rootfs">BUILD SCRIPTS</a></li>
             <li class="otherPlaces"><a href="https://github.com/ev3dev">PACKAGES</a></li>
-            <li class="title">OTHER PLACES</li>
+            <li class="title">OTHER PLACES</li>-->
         </nav>
     </div><!-- end header -->
 
@@ -36,7 +39,9 @@
         <section>
             <div id="title">
                 <div id="logoContainer">
-                    <img id="logo" src="https://avatars3.githubusercontent.com/u/6878323?s=140" />
+                    <a href="index.html">
+                        <img id="logo" src="https://avatars3.githubusercontent.com/u/6878323?s=140" />
+                    </a>
                     <div id="titleHeader" class="clear">
                         <h1>ev3dev</h1>
                         <p>Debian GNU/Linux 7 on LEGO MINDSTORMS EV3!</p>
@@ -67,6 +72,8 @@
                     <li>guile</li>
                     <li>ruby</li>
                     <li>python</li>
+                    <li>Google Go (golang)</li>
+                    <li>nodejs</li>
                 </ul>
 
                 If your favorite language isn't listed, you can still program with the EV3. <code>ev3dev</code> supports standard <code>apt</code> tools, so once you get up-and-running you can install whatever language you like.
@@ -77,8 +84,7 @@
                     <li><a href="https://github.com/fdetro/ev3dev-lang/tree/master/cpp">C++ by @fdetro</a></li>
                     <li><a href="https://github.com/fdetro/ev3dev-lang/tree/master/lua">Lua by @fdetro</a></li>
                     <li><a href="https://github.com/mattrajca/GoEV3">Google Go by @mattrajca</a></li>
-                    <li>Python <a href="https://github.com/mindboards/ev3dev/issues/63#issuecomment-42717732">Rubik's cube solver by @cavenel</a> and <a href="https://gist.github.com/dlech/11098915">balancing robot by @dlech</a></li>
-                    <li><a href="https://github.com/WasabiFan/ev3dev-NodeJS">Node.js by @wasabifan</a></li>
+                    <li><a href="http://wasabifan.github.io/ev3dev-NodeJS/">Node.js by @wasabifan</a></li>
                 </ul>
             </p>
 

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -772,18 +772,29 @@ dt {
   -o-box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2), 0px 1px 0px rgba(0, 0, 0, 0);
   box-shadow: inset 0px 1px 1px rgba(0, 0, 0, 0.2), 0px 1px 0px rgba(0, 0, 0, 0);
 }
+
+#header nav li.projects {
+  float: left; 
+  margin-left: 6px;
+}
+
+#header nav li.home {
+  float: left; 
+  margin-left: 6px;
+}
+
 #header nav li.fork {
-  float: left;
-  margin-left: 0px;
-  }
+  float: right;
+  margin-left: 6px;
+}
 
 #header nav li.wiki {
-  float: left;
+  float: right;
   margin-left: 6px;
 }
 
 #header nav li.issues {
-  float: left; 
+  float: right; 
   margin-left: 6px;
 }
 


### PR DESCRIPTION
I have added [a page](http://wasabifan.github.io/ev3dev/Projects) that we can use to link to other projects. It took a bit or rearranging of the nav links, but I got it to work. The page looks a bit sparse but I don't think that's a problem. Some points of discussion:
- Do we want to include a link to the projects page somewhere in the body of the home page, or is a link in the header enough?
- I included links to the previously discussed projects, but each link points to a different type of resource (YouTube, a GitHub code file, an issue comment, etc). Should I remove the ones that are there until those maintainers ask us to post their project, and specify the page that they want us to use?

I am open to suggestions, and I will happily change things if need be.
