### PR TITLE
Update link to support page in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 ## Submitting issues on GitHub
 
-Please see <http://www.ev3dev.org/issues/>.
+Please see <http://www.ev3dev.org/support/>.


### PR DESCRIPTION
The existing link gets redirected on the client side by our website, which flashes an ugly redirect page in the process. Best to update links instead.