### PR TITLE
Remove sections under "about my issue" in issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -40,12 +40,6 @@ Tips:
 
 
 ### About my issue:
-<!-- Answer the following questions -->
+<!-- Explain exactly what you were trying to do, what you did,
+and what happened as a result. Provide as much information as you can. -->
 
-#### What led up to the situation?
-
-#### What exactly did you do (or not do) that was effective (or ineffective)?
-
-#### What was the outcome of this action?
-
-#### What outcome did you expect instead?


### PR DESCRIPTION
I think these sections are doing more harm than good. In some cases, they're just left blank entirely; in others, all the useful information is included in one section, and the others are filled out with fluff. I have only seen a few instances where people completely filled out the template and included relevant info in each section, but in those cases I suspect that they would have included that information regardless of the template's instructions. Essentially, I think these make opening an issue with useful information more daunting than necessary.

Here's a [search](https://github.com/ev3dev/ev3dev/search?q=what+led+up+to+the+situation&type=Issues) that should list the issues where the template has been used.